### PR TITLE
prog: updated header naming and dragging using overrides 

### DIFF
--- a/vacaro-launcher/src/components/navigation/HeaderName.svelte
+++ b/vacaro-launcher/src/components/navigation/HeaderName.svelte
@@ -1,0 +1,103 @@
+<script>
+  /** Set to `false` to hide the side nav by default */
+  export let expandedByDefault = true;
+
+  /** Set to `true` to open the side nav */
+  export let isSideNavOpen = false;
+
+  /**
+   * Specify the ARIA label for the header
+   * @type {string}
+   */
+  export let uiShellAriaLabel = undefined;
+
+  /**
+   * Specify the `href` attribute
+   * @type {string}
+   */
+  export let href = undefined;
+
+  /**
+   * Specify the company name
+   * @type {string}
+   */
+  export let company = undefined;
+
+  /**
+   * Specify the platform name
+   * Alternatively, use the named slot "platform" (e.g., <span slot="platform">...</span>)
+   */
+  export let platformName = "";
+
+  /** Set to `true` to persist the hamburger menu */
+  export let persistentHamburgerMenu = false;
+
+  /**
+   * The window width (px) at which the SideNav is expanded and the hamburger menu is hidden
+   * 1056 represents the "large" breakpoint in pixels from the Carbon Design System:
+   * small: 320
+   * medium: 672
+   * large: 1056
+   * x-large: 1312
+   * max: 1584
+   */
+  export let expansionBreakpoint = 1056;
+
+  /** Obtain a reference to the HTML anchor element */
+  export let ref = null;
+
+  /**
+   * Specify the icon to render for the closed state.
+   * Defaults to `<Menu size={20} />`
+   * @type {typeof import("svelte").SvelteComponent}
+   */
+  export let iconMenu = Menu;
+
+  /**
+   * Specify the icon to render for the opened state.
+   * Defaults to `<Close size={20} />`
+   * @type {typeof import("svelte").SvelteComponent}
+   */
+  export let iconClose = Close;
+
+  import Close from 'carbon-icons-svelte/lib/Close.svelte';
+  import Menu from 'carbon-icons-svelte/lib/Menu.svelte';
+  import { shouldRenderHamburgerMenu } from "carbon-components-svelte/src/UIShell/navStore.js";
+  import HamburgerMenu from "carbon-components-svelte/src/UIShell/HamburgerMenu.svelte";
+
+  let winWidth = undefined;
+
+  $: isSideNavOpen =
+    expandedByDefault &&
+    winWidth >= expansionBreakpoint &&
+    !persistentHamburgerMenu;
+  $: ariaLabel = company
+    ? `${company} `
+    : "" + (uiShellAriaLabel || $$props["aria-label"] || platformName);
+</script>
+
+<svelte:window bind:innerWidth="{winWidth}" />
+
+<header aria-label="{ariaLabel}" class:bx--header="{true}">
+  <slot name="skip-to-content" />
+  {#if ($shouldRenderHamburgerMenu && winWidth < expansionBreakpoint) || persistentHamburgerMenu}
+    <HamburgerMenu
+      bind:isOpen="{isSideNavOpen}"
+      iconClose="{iconClose}"
+      iconMenu="{iconMenu}"
+    />
+  {/if}
+  <a
+    href="{href}"
+    class:bx--header__name="{true}"
+    bind:this="{ref}"
+    {...$$restProps}
+    on:click
+  >
+    {#if company}
+      <span>{company}&nbsp;</span>
+    {/if}
+    <div name="platform" class:bx--header__name--prefix="{true}">{platformName}</div>
+  </a>
+  <slot />
+</header>

--- a/vacaro-launcher/src/components/navigation/HeaderUtilitiesDrag.svelte
+++ b/vacaro-launcher/src/components/navigation/HeaderUtilitiesDrag.svelte
@@ -1,0 +1,3 @@
+<div class:bx--header__global="{true}" data-tauri-drag-region>
+  <slot />
+</div>

--- a/vacaro-launcher/src/routes/__layout.svelte
+++ b/vacaro-launcher/src/routes/__layout.svelte
@@ -42,9 +42,10 @@
 	import InformationSquare from 'carbon-icons-svelte/lib/InformationSquare.svelte';
 	import Share from 'carbon-icons-svelte/lib/Share.svelte';
 	import HeaderNavItemHref from '../components/navigation/HeaderNavItemHref.svelte';
-
+	import HeaderUtilitiesDrag from '../components/navigation/HeaderUtilitiesDrag.svelte';
 	import WarningModal from '../components/theme/WarningModal.svelte';
 	import ContextMenuLayout from '../components/ContextMenuLayout.svelte';
+	import HeaderName from '../components/navigation/HeaderName.svelte';
 
 	let isOpen = false;
 	let isSideNavOpen = false;
@@ -97,7 +98,7 @@
 </script>
 
 <div>
-	<Header
+	<HeaderName
 		data-tauri-drag-region
 		class="titlebar"
 		company="Vacaro"
@@ -124,7 +125,7 @@
 				<HeaderNavItemHref Href="/docs/self-hosting" Text="Self Hosting" StartsWith="false" />
 			</HeaderNavMenu>
 		</HeaderNav>
-		<HeaderUtilities data-tauri-drag-region>
+		<HeaderUtilitiesDrag>
 			{#if themeBool == true}
 				<HeaderGlobalAction
 					on:click={() => themeChange()}
@@ -155,7 +156,7 @@
 					<HeaderPanelLink>Switcher item 5</HeaderPanelLink>
 				</HeaderPanelLinks>
 			</HeaderAction>
-		</HeaderUtilities>
+		</HeaderUtilitiesDrag>
 		<div
 			style="width=100%; margin-left: 20px; margin-right: 1.5px; height=100%"
 			data-tauri-drag-region={true}
@@ -188,7 +189,7 @@
 				icon={WindowCloseButton}
 			/>
 		</div>
-	</Header>
+	</HeaderName>
 
 	<SideNav rail bind:isOpen={isSideNavOpen}>
 		<!-- style={themeBackground} -->
@@ -255,6 +256,7 @@
 			color: white;
 			fill: transparent !important;
 			/* margin-bottom: 17px; */
+			margin-right: -1px;
 		}
 		.closebutton:hover {
 			background-color: #e81123;


### PR DESCRIPTION
- fix: single pixel shift on close button [overrides]
- fix: product and company name bold invert (focus on the vacaro name instead of on the launcher text) [overrides]
- fix: tauri drag region on HeaderUtilities components [overrides]

![image-full](https://user-images.githubusercontent.com/71338293/179265282-6a4a0106-d0ed-488b-bec9-23422de9a95f.png)
![image-compare](https://user-images.githubusercontent.com/71338293/179265894-6f9ac553-0f0d-412b-8e38-864b7cb78a48.png)
![image-button-compare](https://user-images.githubusercontent.com/71338293/179266980-e8d36fba-937e-47e5-9ef7-9ad25504b7fc.png)

